### PR TITLE
chore(config): H2 dev profile and Flyway baseline migration

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=prueba-tecnica-ecommerce

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,24 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:ordersdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: password
+  jpa:
+    hibernate:
+        ddl-auto: validate
+        show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: true
+    open-in-view: false
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  server:
+    port: 8080

--- a/src/main/resources/db/migration/V1__baseline.sql
+++ b/src/main/resources/db/migration/V1__baseline.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS orders (
+    id VARCHAR(36) PRIMARY KEY,
+    customer_id VARCHAR(255) NOT NULL,
+    status VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    version BIGINT DEFAULT 0 NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS order_items (
+    id BIGINT PRIMARY KEY,
+    order_id VARCHAR(36) NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+    product_id VARCHAR(255) NOT NULL,
+    quantity INT NOT NULL,
+    unit_price NUMERIC(19,2) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_orders_customer ON orders(customer_id);
+CREATE INDEX IF NOT EXISTS idx_orders_status ON orders(status);


### PR DESCRIPTION
Agregué un perfil con H2 para el entorno de desarrollo y configuré Flyway con una migración base.  La idea es que se pueda levantar la app de forma local sin depender de una base externa y tener un esquema inicial controlado desde el inicio.

**Cambios principales**
- Nuevo perfil `dev` con H2.
- Dependencias de Flyway.
- Migración inicial `V1__baseline.sql`.
- Ajustes en `application-dev.yml`.

**Pruebas**
Probado levantando la app con el perfil `dev`, Flyway corre la migración base sin errores.