### PR TITLE
feat(persistence): finalize OrderMapper with toEntity/toDomain conver…

### DIFF
--- a/src/main/java/org/example/pruebatecnicaecommerce/domain/model/inventory/Inventory.java
+++ b/src/main/java/org/example/pruebatecnicaecommerce/domain/model/inventory/Inventory.java
@@ -24,6 +24,10 @@ public class Inventory {
         return new Inventory(productId, initialStock, 0);
     }
 
+    public static Inventory restore(String productId, int stock, long version) {
+        return new Inventory(productId, stock, version);
+    }
+
     public void reserve(int quantity) {
         if (quantity <= 0) {
             throw new IllegalArgumentException("Quantity must be greater than zero");

--- a/src/main/java/org/example/pruebatecnicaecommerce/domain/model/inventory/InventoryRepository.java
+++ b/src/main/java/org/example/pruebatecnicaecommerce/domain/model/inventory/InventoryRepository.java
@@ -1,4 +1,6 @@
-package org.example.pruebatecnicaecommerce.domain.model.Inventory;
+package org.example.pruebatecnicaecommerce.domain.model.inventory;
+
+import org.example.pruebatecnicaecommerce.domain.inventory.Inventory;
 
 import java.util.Optional;
 

--- a/src/main/java/org/example/pruebatecnicaecommerce/domain/model/order/Order.java
+++ b/src/main/java/org/example/pruebatecnicaecommerce/domain/model/order/Order.java
@@ -1,4 +1,4 @@
-package org.example.pruebatecnicaecommerce.domain.model.Order;
+package org.example.pruebatecnicaecommerce.domain.model.order;
 
 import lombok.Getter;
 
@@ -17,18 +17,16 @@ public class Order {
     private long version;
     private final List<OrderItem> items = new ArrayList<>();
 
-    // Constructor privado → obliga a usar el factory
+
     private Order(UUID id, String customerId, OrderStatus status,
-                  Instant createdAt, long version, List<OrderItem> items) {
+                  Instant createdAt, long version) {
         this.id = id;
         this.customerId = customerId;
         this.status = status;
         this.createdAt = createdAt;
         this.version = version;
-        if (items != null) {
-            this.items.addAll(items);
-        }
     }
+
 
     public static Order create(String customerId) {
         return new Order(
@@ -36,14 +34,21 @@ public class Order {
                 customerId,
                 OrderStatus.CREATED,
                 Instant.now(),
-                0,
-                new ArrayList<>()
+                0
         );
     }
 
+
+    public static Order restore(UUID id, String customerId, OrderStatus status,
+                                Instant createdAt, long version) {
+        return new Order(id, customerId, status, createdAt, version);
+    }
+
+
+
     public void addItem(OrderItem item) {
         if (status != OrderStatus.CREATED) {
-            throw new IllegalStateException("Cannot add items once order is not in CREATED status");
+            throw new IllegalStateException("No se pueden agregar ítems cuando la orden ya no está en estado CREATED");
         }
         this.items.add(item);
     }
@@ -51,7 +56,7 @@ public class Order {
     public void changeStatus(OrderStatus next) {
         if (!this.status.canTransitionTo(next)) {
             throw new IllegalStateException(
-                    "Invalid transition from " + this.status + " to " + next
+                    "Transición inválida de " + this.status + " a " + next
             );
         }
         this.status = next;

--- a/src/main/java/org/example/pruebatecnicaecommerce/domain/model/order/OrderItem.java
+++ b/src/main/java/org/example/pruebatecnicaecommerce/domain/model/order/OrderItem.java
@@ -1,4 +1,4 @@
-package org.example.pruebatecnicaecommerce.domain.model.Order;
+package org.example.pruebatecnicaecommerce.domain.model.order;
 
 import lombok.Value;
 

--- a/src/main/java/org/example/pruebatecnicaecommerce/domain/model/order/OrderRepository.java
+++ b/src/main/java/org/example/pruebatecnicaecommerce/domain/model/order/OrderRepository.java
@@ -1,4 +1,4 @@
-package org.example.pruebatecnicaecommerce.domain.model.Order;
+package org.example.pruebatecnicaecommerce.domain.model.order;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/org/example/pruebatecnicaecommerce/domain/model/order/OrderStatus.java
+++ b/src/main/java/org/example/pruebatecnicaecommerce/domain/model/order/OrderStatus.java
@@ -1,4 +1,4 @@
-package org.example.pruebatecnicaecommerce.domain.model.Order;
+package org.example.pruebatecnicaecommerce.domain.model.order;
 
 public enum OrderStatus {
     CREATED,PAID,SHIPPED,DELIVERED,CANCELLED;

--- a/src/main/java/org/example/pruebatecnicaecommerce/infrastructure/persistence/adapter/InventoryJpaRepositoryAdapter.java
+++ b/src/main/java/org/example/pruebatecnicaecommerce/infrastructure/persistence/adapter/InventoryJpaRepositoryAdapter.java
@@ -1,0 +1,30 @@
+package org.example.pruebatecnicaecommerce.infrastructure.persistence.adapter;
+
+import lombok.RequiredArgsConstructor;
+import org.example.pruebatecnicaecommerce.domain.inventory.Inventory;
+
+import org.example.pruebatecnicaecommerce.domain.model.inventory.InventoryRepository;
+import org.example.pruebatecnicaecommerce.infrastructure.persistence.inventory.JpaInventoryRepository;
+import org.example.pruebatecnicaecommerce.infrastructure.persistence.mapper.InventoryMapper;
+
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class InventoryJpaRepositoryAdapter implements InventoryRepository {
+
+
+      private final JpaInventoryRepository jpaRepository;
+
+    @Override
+    public Optional<Inventory> findByProductId(String productId) {
+        return jpaRepository.findById(productId).map(InventoryMapper::toDomain);
+    }
+
+    @Override
+    public void save(Inventory inventory) {
+        jpaRepository.save(InventoryMapper.toEntity(inventory));
+    }
+}

--- a/src/main/java/org/example/pruebatecnicaecommerce/infrastructure/persistence/adapter/OrderJpaRepositoryAdapter.java
+++ b/src/main/java/org/example/pruebatecnicaecommerce/infrastructure/persistence/adapter/OrderJpaRepositoryAdapter.java
@@ -1,0 +1,38 @@
+package org.example.pruebatecnicaecommerce.infrastructure.persistence.adapter;
+
+import lombok.RequiredArgsConstructor;
+
+import org.example.pruebatecnicaecommerce.domain.model.order.Order;
+import org.example.pruebatecnicaecommerce.domain.model.order.OrderRepository;
+import org.example.pruebatecnicaecommerce.infrastructure.persistence.mapper.OrderMapper;
+import org.example.pruebatecnicaecommerce.infrastructure.persistence.order.JpaOrderRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderJpaRepositoryAdapter implements OrderRepository {
+
+    private final JpaOrderRepository jpaRepository;
+
+    @Override
+    public void save(Order order) {
+        jpaRepository.save(OrderMapper.toEntity(order));
+    }
+
+    @Override
+    public Optional<Order> findById(UUID orderId) {
+        return jpaRepository.findById(orderId).map(OrderMapper::toDomain);
+    }
+
+    @Override
+    public List<Order> findByCustomerId(String customerId) {
+        return jpaRepository.findByCustomerId(customerId)
+                .stream()
+                .map(OrderMapper::toDomain)
+                .toList();
+    }
+}

--- a/src/main/java/org/example/pruebatecnicaecommerce/infrastructure/persistence/inventory/InventoryEntity.java
+++ b/src/main/java/org/example/pruebatecnicaecommerce/infrastructure/persistence/inventory/InventoryEntity.java
@@ -1,0 +1,21 @@
+package org.example.pruebatecnicaecommerce.infrastructure.persistence.inventory;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "inventory")
+@Getter
+@Setter
+@NoArgsConstructor
+public class InventoryEntity {
+    @Id
+    private String productId;
+
+    private int stock;
+
+    @Version
+    private long version;
+}

--- a/src/main/java/org/example/pruebatecnicaecommerce/infrastructure/persistence/inventory/JpaInventoryRepository.java
+++ b/src/main/java/org/example/pruebatecnicaecommerce/infrastructure/persistence/inventory/JpaInventoryRepository.java
@@ -1,0 +1,7 @@
+package org.example.pruebatecnicaecommerce.infrastructure.persistence.inventory;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaInventoryRepository extends JpaRepository<InventoryEntity, String> {
+
+}

--- a/src/main/java/org/example/pruebatecnicaecommerce/infrastructure/persistence/mapper/InventoryMapper.java
+++ b/src/main/java/org/example/pruebatecnicaecommerce/infrastructure/persistence/mapper/InventoryMapper.java
@@ -1,0 +1,24 @@
+package org.example.pruebatecnicaecommerce.infrastructure.persistence.mapper;
+
+import org.example.pruebatecnicaecommerce.domain.inventory.Inventory;
+import org.example.pruebatecnicaecommerce.infrastructure.persistence.inventory.InventoryEntity;
+
+
+public class InventoryMapper {
+
+    public static InventoryEntity toEntity(Inventory inventory) {
+        InventoryEntity entity = new InventoryEntity();
+        entity.setProductId(inventory.getProductId());
+        entity.setStock(inventory.getStock());
+        entity.setVersion(inventory.getVersion());
+        return entity;
+    }
+
+    public static Inventory toDomain(InventoryEntity entity) {
+        return Inventory.restore(
+                entity.getProductId(),
+                entity.getStock(),
+                entity.getVersion()
+        );
+    }
+}

--- a/src/main/java/org/example/pruebatecnicaecommerce/infrastructure/persistence/mapper/OrderMapper.java
+++ b/src/main/java/org/example/pruebatecnicaecommerce/infrastructure/persistence/mapper/OrderMapper.java
@@ -1,0 +1,51 @@
+package org.example.pruebatecnicaecommerce.infrastructure.persistence.mapper;
+
+
+
+import org.example.pruebatecnicaecommerce.domain.model.order.Order;
+import org.example.pruebatecnicaecommerce.domain.model.order.OrderItem;
+import org.example.pruebatecnicaecommerce.infrastructure.persistence.order.OrderEntity;
+import org.example.pruebatecnicaecommerce.infrastructure.persistence.order.OrderItemEntity;
+
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class OrderMapper {
+
+    public static OrderEntity toEntity(Order order) {
+        OrderEntity entity = new OrderEntity();
+        entity.setId(order.getId());
+        entity.setCustomerId(order.getCustomerId());
+        entity.setStatus(order.getStatus());
+        entity.setCreatedAt(order.getCreatedAt());
+        entity.setVersion(order.getVersion());
+        entity.setItems(order.getItems().stream()
+                .map(item -> toItemEntity(item, entity))
+                .collect(Collectors.toList()));
+        return entity;
+    }
+
+    public static Order toDomain(OrderEntity entity) {
+        Order order = Order.restore(
+                entity.getId(),
+                entity.getCustomerId(),
+                entity.getStatus(),
+                entity.getCreatedAt(),
+                entity.getVersion()
+        );
+        entity.getItems().forEach(item -> order.addItem(
+                new OrderItem(item.getProductId(), item.getQuantity(), item.getUnitPrice())
+        ));
+        return order;
+    }
+
+    private static OrderItemEntity toItemEntity(OrderItem item, OrderEntity orderEntity) {
+        OrderItemEntity entity = new OrderItemEntity();
+        entity.setId(UUID.randomUUID());
+        entity.setOrder(orderEntity);
+        entity.setProductId(item.getProductId());
+        entity.setQuantity(item.getQuantity());
+        entity.setUnitPrice(item.getUnitPrice());
+        return entity;
+    }
+}

--- a/src/main/java/org/example/pruebatecnicaecommerce/infrastructure/persistence/order/JpaOrderRepository.java
+++ b/src/main/java/org/example/pruebatecnicaecommerce/infrastructure/persistence/order/JpaOrderRepository.java
@@ -1,0 +1,10 @@
+package org.example.pruebatecnicaecommerce.infrastructure.persistence.order;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface JpaOrderRepository  extends JpaRepository<OrderEntity, UUID> {
+    List<OrderEntity> findByCustomerId(String customerId);
+}

--- a/src/main/java/org/example/pruebatecnicaecommerce/infrastructure/persistence/order/OrderEntity.java
+++ b/src/main/java/org/example/pruebatecnicaecommerce/infrastructure/persistence/order/OrderEntity.java
@@ -1,0 +1,36 @@
+package org.example.pruebatecnicaecommerce.infrastructure.persistence.order;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.example.pruebatecnicaecommerce.domain.model.order.OrderStatus;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "orders")
+@Setter
+@Getter
+@NoArgsConstructor
+public class OrderEntity {
+
+    @Id
+    private UUID id;
+
+    private String customerId;
+
+    @Enumerated(EnumType.STRING)
+    private OrderStatus status;
+
+    private Instant createdAt;
+
+    @Version
+    private long version;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    private List<OrderItemEntity> items = new ArrayList<>();
+}

--- a/src/main/java/org/example/pruebatecnicaecommerce/infrastructure/persistence/order/OrderItemEntity.java
+++ b/src/main/java/org/example/pruebatecnicaecommerce/infrastructure/persistence/order/OrderItemEntity.java
@@ -1,0 +1,31 @@
+package org.example.pruebatecnicaecommerce.infrastructure.persistence.order;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Entity
+@Table(name = "order_items")
+@Getter
+@Setter
+@NoArgsConstructor
+public class OrderItemEntity {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    private String productId;
+
+    private int quantity;
+
+    private BigDecimal unitPrice;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id",nullable = false)
+    private OrderEntity order;
+}

--- a/src/main/resources/db/migration/V1__baseline.sql
+++ b/src/main/resources/db/migration/V1__baseline.sql
@@ -7,12 +7,20 @@ CREATE TABLE IF NOT EXISTS orders (
 );
 
 CREATE TABLE IF NOT EXISTS order_items (
-    id BIGINT PRIMARY KEY,
+    id VARCHAR(36) PRIMARY KEY,
     order_id VARCHAR(36) NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
     product_id VARCHAR(255) NOT NULL,
     quantity INT NOT NULL,
     unit_price NUMERIC(19,2) NOT NULL
-);
+    );
+
+
+CREATE TABLE IF NOT EXISTS inventory (
+    product_id VARCHAR(255) PRIMARY KEY,
+    stock INT NOT NULL,
+    version BIGINT DEFAULT 0 NOT NULL
+    );
+
 
 CREATE INDEX IF NOT EXISTS idx_orders_customer ON orders(customer_id);
 CREATE INDEX IF NOT EXISTS idx_orders_status ON orders(status);


### PR DESCRIPTION
Se completó la implementación de los mappers con los métodos de conversión entre entidad y dominio.  

**Cambios principales**
- Método `toEntity` implementado para transformar objetos de dominio a entidad.
- Método `toDomain` para convertir entidades a objetos de dominio.
- Ajustes menores en la capa de persistencia.

**Pruebas**
Verificado que la conversión funciona correctamente en escenarios básicos de guardado y recuperación.
